### PR TITLE
ramcli

### DIFF
--- a/services/splitdump/type_instancedeployment.go
+++ b/services/splitdump/type_instancedeployment.go
@@ -37,7 +37,8 @@ type InstanceDeployment struct {
 			GCF gcf.Parameters
 		}
 		Instance struct {
-			SplitThresholdLineNumber int64 `yaml:"splitThresholdLineNumber"`
+			SplitThresholdLineNumber   int64 `yaml:"splitThresholdLineNumber"`
+			ScannerBufferSizeKiloBytes int   `yaml:"scannerBufferSizeKiloBytes"`
 		}
 	}
 }

--- a/utilities/deploy/doc.go
+++ b/utilities/deploy/doc.go
@@ -12,12 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ramcli
-
-import "strings"
-
-// getServiceAndInstanceNames split the instance folder relative path to extract 1) serviceName 2) instanceName
-func getServiceAndInstanceNames(instanceFolderRelativePath string) (serviceName, instanceName string) {
-	parts := strings.Split(instanceFolderRelativePath, "/")
-	return parts[1], parts[3]
-}
+// Package deploy defines the core structure for deployents and common APIs
+package deploy

--- a/utilities/deploy/type_core.go
+++ b/utilities/deploy/type_core.go
@@ -41,6 +41,7 @@ type Core struct {
 	EnvironmentName             string
 	InstanceName                string
 	ServiceName                 string
+	AssetType                   string
 	ProjectNumber               int64
 	RepositoryPath              string
 	RAMVersion                  string

--- a/utilities/gbq/doc.go
+++ b/utilities/gbq/doc.go
@@ -12,12 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ramcli
-
-import "strings"
-
-// getServiceAndInstanceNames split the instance folder relative path to extract 1) serviceName 2) instanceName
-func getServiceAndInstanceNames(instanceFolderRelativePath string) (serviceName, instanceName string) {
-	parts := strings.Split(instanceFolderRelativePath, "/")
-	return parts[1], parts[3]
-}
+// Package gbq helps with google Bigquery
+package gbq

--- a/utilities/gcb/doc.go
+++ b/utilities/gcb/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package gcb helps with Google cloud build
+// Package gcb helps with Google Cloud Build
 package gcb

--- a/utilities/gcb/meth_triggerdeployment_deploy.go
+++ b/utilities/gcb/meth_triggerdeployment_deploy.go
@@ -124,5 +124,9 @@ func (triggerDeployment *TriggerDeployment) tagRegex() (tagRegex string) {
 	instanceTagRegex := fmt.Sprintf("(%s-v\\d*.\\d*.\\d*-%s)", triggerDeployment.Core.InstanceName, triggerDeployment.Core.EnvironmentName)
 	serviceTagRegex := fmt.Sprintf("(%s-v\\d*.\\d*.\\d*-%s)", triggerDeployment.Core.ServiceName, triggerDeployment.Core.EnvironmentName)
 	solutionTagRegex := fmt.Sprintf("(%s-v\\d*.\\d*.\\d*-%s)", ram.SolutionName, triggerDeployment.Core.EnvironmentName)
-	return fmt.Sprintf("%s|%s|%s", instanceTagRegex, serviceTagRegex, solutionTagRegex)
+	if triggerDeployment.Artifacts.AssetShortTypeName == "" {
+		return fmt.Sprintf("%s|%s|%s", instanceTagRegex, serviceTagRegex, solutionTagRegex)
+	}
+	assetTypeRegex := fmt.Sprintf("(%s-v\\d*.\\d*.\\d*-%s)", triggerDeployment.Artifacts.AssetShortTypeName, triggerDeployment.Core.EnvironmentName)
+	return fmt.Sprintf("%s|%s|%s|%s", instanceTagRegex, serviceTagRegex, solutionTagRegex, assetTypeRegex)
 }

--- a/utilities/gcb/type_triggerdeployment.go
+++ b/utilities/gcb/type_triggerdeployment.go
@@ -25,6 +25,7 @@ type TriggerDeployment struct {
 	Artifacts struct {
 		ProjectsTriggersService *cloudbuild.ProjectsTriggersService `yaml:"-"`
 		BuildTrigger            cloudbuild.BuildTrigger
+		AssetShortTypeName      string
 	}
 	Core     *deploy.Core
 	Settings struct {

--- a/utilities/gcf/doc.go
+++ b/utilities/gcf/doc.go
@@ -12,12 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ramcli
-
-import "strings"
-
-// getServiceAndInstanceNames split the instance folder relative path to extract 1) serviceName 2) instanceName
-func getServiceAndInstanceNames(instanceFolderRelativePath string) (serviceName, instanceName string) {
-	parts := strings.Split(instanceFolderRelativePath, "/")
-	return parts[1], parts[3]
-}
+// Package gcf helps with Google cloud functions
+package gcf

--- a/utilities/ramcli/func_checkargumemts.go
+++ b/utilities/ramcli/func_checkargumemts.go
@@ -33,6 +33,7 @@ func (deployment *Deployment) CheckArguments() {
 	flag.BoolVar(&deployment.Core.Commands.Dumpsettings, "dump", false, fmt.Sprintf("dump all settings in %s", ram.SettingsFileName))
 	flag.StringVar(&deployment.Core.RepositoryPath, "repo", ".", "Path to the root of the code repository")
 	flag.StringVar(&deployment.Core.RamcliServiceAccount, "ramclisa", "", "Email of Service Account used when running ramcli")
+	var assetType = flag.String("asset", "", "asset type e.g. k8s.io/Pod")
 	var microserviceFolderName = flag.String("service", "", "Microservice folder name")
 	var instanceFolderName = flag.String("instance", "", "Instance folder name")
 	flag.StringVar(&deployment.Core.EnvironmentName, "environment", ram.DevelopmentEnvironmentName, "Environment name")
@@ -44,9 +45,9 @@ func (deployment *Deployment) CheckArguments() {
 			log.Fatalln("Missing service argument")
 		}
 		instanceRelativePath := fmt.Sprintf("%s/%s/%s/%s", ram.MicroserviceParentFolderName, *microserviceFolderName, ram.InstancesFolderName, *instanceFolderName)
+		deployment.Core.InstanceFolderRelativePaths = []string{instanceRelativePath}
 		instancePath := fmt.Sprintf("%s/%s", deployment.Core.RepositoryPath, instanceRelativePath)
 		ram.CheckPath(instancePath)
-		deployment.Core.InstanceFolderRelativePaths = []string{instanceRelativePath}
 		return
 	}
 
@@ -54,6 +55,11 @@ func (deployment *Deployment) CheckArguments() {
 		// case one microservice
 		deployment.Core.InstanceFolderRelativePaths = ram.GetChild(deployment.Core.RepositoryPath, fmt.Sprintf("%s/%s/%s", ram.MicroserviceParentFolderName, *microserviceFolderName, ram.InstancesFolderName))
 	} else {
+		// case one assetType
+		if *assetType != "" {
+			deployment.Core.AssetType = *assetType
+			return
+		}
 		// case all
 		for _, microserviceRelativeFolderPath := range ram.GetChild(deployment.Core.RepositoryPath, ram.MicroserviceParentFolderName) {
 			instanceFolderRelativePaths := ram.GetChild(deployment.Core.RepositoryPath, fmt.Sprintf("%s/%s", microserviceRelativeFolderPath, ram.InstancesFolderName))

--- a/utilities/ramcli/func_checkargumemts.go
+++ b/utilities/ramcli/func_checkargumemts.go
@@ -24,7 +24,7 @@ import (
 
 // CheckArguments check cli arguments and build the list of microservices instances
 func (deployment *Deployment) CheckArguments() {
-	deployment.Core.GoVersion, deployment.Core.RAMVersion = GetVersions()
+	deployment.Core.GoVersion, deployment.Core.RAMVersion = getVersions()
 	// flag.BoolVar(&settings.Commands.Makeyaml, "migrate-to-yaml", false, "make yaml settings files for setting.sh file")
 	flag.BoolVar(&deployment.Core.Commands.Initialize, "init", false, "initial setup to be launched first, before manual, aka not automatable setup tasks")
 	flag.BoolVar(&deployment.Core.Commands.ConfigureAssetTypes, "config", false, "For assets types defined in solution.yaml writes setfeeds, dumpinventory, stream2bq instance.yaml files and subfolders")

--- a/utilities/ramcli/func_getversions.go
+++ b/utilities/ramcli/func_getversions.go
@@ -23,8 +23,8 @@ import (
 	"github.com/BrunoReboul/ram/utilities/ram"
 )
 
-// GetVersions look for a go.mod in the curent path, returns Go and RAM versions, crashes execution on errors
-func GetVersions() (goVersion, ramVersion string) {
+// getVersions look for a go.mod in the curent path, returns Go and RAM versions, crashes execution on errors
+func getVersions() (goVersion, ramVersion string) {
 	goModFilePath := "./go.mod"
 	ram.CheckPath(goModFilePath)
 	file, err := os.Open(goModFilePath)

--- a/utilities/ramcli/meth_deployment_configuresplitdumpsingleinstance.go
+++ b/utilities/ramcli/meth_deployment_configuresplitdumpsingleinstance.go
@@ -41,6 +41,7 @@ func (deployment *Deployment) configureSplitDumpSingleInstance() (err error) {
 
 	// Default value
 	splitdumpInstance.SplitThresholdLineNumber = 1000
+	splitdumpInstance.ScannerBufferSizeKiloBytes = 512
 
 	instanceFolderPath := strings.Replace(
 		fmt.Sprintf("%s/%s_single_instance",

--- a/utilities/ramcli/meth_deployment_deploygcbtrigger.go
+++ b/utilities/ramcli/meth_deployment_deploygcbtrigger.go
@@ -15,6 +15,9 @@
 package ramcli
 
 import (
+	"strings"
+
+	"github.com/BrunoReboul/ram/utilities/cai"
 	"github.com/BrunoReboul/ram/utilities/gcb"
 )
 
@@ -22,5 +25,8 @@ func (deployment *Deployment) deployGCBTrigger() (err error) {
 	triggerDeployment := gcb.NewTriggerDeployment()
 	triggerDeployment.Core = &deployment.Core
 	triggerDeployment.Settings.Service.GCB = deployment.Settings.Service.GCB
+	if deployment.Core.AssetType != "" {
+		triggerDeployment.Artifacts.AssetShortTypeName = strings.Replace(cai.GetAssetShortTypeName(deployment.Core.AssetType), "-", "_", -1)
+	}
 	return triggerDeployment.Deploy()
 }

--- a/utilities/ramcli/ramcli.go
+++ b/utilities/ramcli/ramcli.go
@@ -148,7 +148,7 @@ func RAMCli(deployment *Deployment) (err error) {
 	default:
 		log.Printf("found %d instance(s)", len(deployment.Core.InstanceFolderRelativePaths))
 		for _, instanceFolderRelativePath := range deployment.Core.InstanceFolderRelativePaths {
-			deployment.Core.ServiceName, deployment.Core.InstanceName = GetServiceAndInstanceNames(instanceFolderRelativePath)
+			deployment.Core.ServiceName, deployment.Core.InstanceName = getServiceAndInstanceNames(instanceFolderRelativePath)
 			switch deployment.Core.ServiceName {
 			case "setfeeds":
 				deployment.deploySetFeeds()

--- a/utilities/solution/doc.go
+++ b/utilities/solution/doc.go
@@ -12,12 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ramcli
-
-import "strings"
-
-// getServiceAndInstanceNames split the instance folder relative path to extract 1) serviceName 2) instanceName
-func getServiceAndInstanceNames(instanceFolderRelativePath string) (serviceName, instanceName string) {
-	parts := strings.Split(instanceFolderRelativePath, "/")
-	return parts[1], parts[3]
-}
+// Package solution defines the structure for solution settings
+package solution


### PR DESCRIPTION
- splitdump scanner buffer size configurable
- improve go code documentation
- improve go code export only when needed
- ramcli transversal deployments by assettype
