### PR TITLE
move output topics to solution yaml and scanner size 128KB

### DIFF
--- a/services/getgroupsettings/core.go
+++ b/services/getgroupsettings/core.go
@@ -60,7 +60,7 @@ func Initialize(ctx context.Context, global *Global) {
 	}
 
 	gciAdminUserToImpersonate := instanceDeployment.Settings.Instance.GCI.SuperAdminEmail
-	global.outputTopicName = instanceDeployment.Settings.Service.OutputTopicName
+	global.outputTopicName = instanceDeployment.Core.SolutionSettings.Hosting.Pubsub.TopicNames.GCIGroupSettings
 	global.projectID = instanceDeployment.Core.SolutionSettings.Hosting.ProjectID
 	global.retryTimeOutSeconds = instanceDeployment.Settings.Service.GCF.RetryTimeOutSeconds
 	keyJSONFilePath := "./" + instanceDeployment.Settings.Service.KeyJSONFileName

--- a/services/getgroupsettings/meth_instancedeployment_deploygpstopic.go
+++ b/services/getgroupsettings/meth_instancedeployment_deploygpstopic.go
@@ -28,7 +28,7 @@ func (instanceDeployment *InstanceDeployment) deployGPSTopic() (err error) {
 		return err
 	}
 
-	topicDeployment.Settings.TopicName = instanceDeployment.Settings.Service.OutputTopicName
+	topicDeployment.Settings.TopicName = instanceDeployment.Core.SolutionSettings.Hosting.Pubsub.TopicNames.GCIGroupSettings
 	err = topicDeployment.Deploy()
 	if err != nil {
 		return err

--- a/services/getgroupsettings/meth_instancedeployment_situate.go
+++ b/services/getgroupsettings/meth_instancedeployment_situate.go
@@ -23,6 +23,6 @@ func (instanceDeployment *InstanceDeployment) Situate() (err error) {
 	instanceDeployment.Settings.Service.GCF.FunctionType = "backgroundPubSub"
 	instanceDeployment.Settings.Service.GCF.Description = fmt.Sprintf("For each group advertised from Pubusub topic %s, get the group settings into pubsub topic %s",
 		instanceDeployment.Settings.Instance.GCF.TriggerTopic,
-		instanceDeployment.Settings.Service.OutputTopicName)
+		instanceDeployment.Core.SolutionSettings.Hosting.Pubsub.TopicNames.GCIGroupSettings)
 	return nil
 }

--- a/services/getgroupsettings/type_instancedeployment.go
+++ b/services/getgroupsettings/type_instancedeployment.go
@@ -36,7 +36,6 @@ type InstanceDeployment struct {
 			GCB             gcb.Parameters
 			GCF             gcf.Parameters
 			KeyJSONFileName string `yaml:"keyJSONFileName"`
-			OutputTopicName string `yaml:"outputTopicName"`
 		}
 		Instance struct {
 			GCF gcf.Event
@@ -84,7 +83,6 @@ func NewInstanceDeployment() *InstanceDeployment {
 	instanceDeployment.Settings.Service.GCF.Timeout = "60s"
 
 	instanceDeployment.Settings.Service.KeyJSONFileName = "key.json"
-	instanceDeployment.Settings.Service.OutputTopicName = "gci-groupSettings"
 
 	return &instanceDeployment
 }

--- a/services/listgroupmembers/core.go
+++ b/services/listgroupmembers/core.go
@@ -77,7 +77,7 @@ func Initialize(ctx context.Context, global *Global) {
 
 	gciAdminUserToImpersonate := instanceDeployment.Settings.Instance.GCI.SuperAdminEmail
 	global.logEventEveryXPubSubMsg = instanceDeployment.Settings.Service.LogEventEveryXPubSubMsg
-	global.outputTopicName = instanceDeployment.Settings.Service.OutputTopicName
+	global.outputTopicName = instanceDeployment.Core.SolutionSettings.Hosting.Pubsub.TopicNames.GCIGroupMembers
 	global.maxResultsPerPage = instanceDeployment.Settings.Service.MaxResultsPerPage
 	global.retryTimeOutSeconds = instanceDeployment.Settings.Service.GCF.RetryTimeOutSeconds
 	keyJSONFilePath := "./" + instanceDeployment.Settings.Service.KeyJSONFileName

--- a/services/listgroupmembers/meth_instancedeployment_deploygpstopic.go
+++ b/services/listgroupmembers/meth_instancedeployment_deploygpstopic.go
@@ -28,7 +28,7 @@ func (instanceDeployment *InstanceDeployment) deployGPSTopic() (err error) {
 		return err
 	}
 
-	topicDeployment.Settings.TopicName = instanceDeployment.Settings.Service.OutputTopicName
+	topicDeployment.Settings.TopicName = instanceDeployment.Core.SolutionSettings.Hosting.Pubsub.TopicNames.GCIGroupMembers
 	err = topicDeployment.Deploy()
 	if err != nil {
 		return err

--- a/services/listgroupmembers/meth_instancedeployment_situate.go
+++ b/services/listgroupmembers/meth_instancedeployment_situate.go
@@ -23,6 +23,6 @@ func (instanceDeployment *InstanceDeployment) Situate() (err error) {
 	instanceDeployment.Settings.Service.GCF.FunctionType = "backgroundPubSub"
 	instanceDeployment.Settings.Service.GCF.Description = fmt.Sprintf("For each group advertised from Pubusub topic %s, list the group members into pubsub topic %s",
 		instanceDeployment.Settings.Instance.GCF.TriggerTopic,
-		instanceDeployment.Settings.Service.OutputTopicName)
+		instanceDeployment.Core.SolutionSettings.Hosting.Pubsub.TopicNames.GCIGroupMembers)
 	return nil
 }

--- a/services/listgroupmembers/type_instancedeployment.go
+++ b/services/listgroupmembers/type_instancedeployment.go
@@ -38,7 +38,6 @@ type InstanceDeployment struct {
 			KeyJSONFileName         string `yaml:"keyJSONFileName"`
 			LogEventEveryXPubSubMsg uint64 `yaml:"logEventEveryXPubSubMsg"`
 			MaxResultsPerPage       int64  `yaml:"maxResultsPerPage"`
-			OutputTopicName         string `yaml:"outputTopicName"`
 		}
 		Instance struct {
 			GCF gcf.Event
@@ -88,7 +87,6 @@ func NewInstanceDeployment() *InstanceDeployment {
 	instanceDeployment.Settings.Service.KeyJSONFileName = "key.json"
 	instanceDeployment.Settings.Service.LogEventEveryXPubSubMsg = 1000
 	instanceDeployment.Settings.Service.MaxResultsPerPage = 200
-	instanceDeployment.Settings.Service.OutputTopicName = "gci-groupMembers"
 
 	return &instanceDeployment
 }

--- a/utilities/ramcli/meth_deployment_configuresplitdumpsingleinstance.go
+++ b/utilities/ramcli/meth_deployment_configuresplitdumpsingleinstance.go
@@ -41,7 +41,7 @@ func (deployment *Deployment) configureSplitDumpSingleInstance() (err error) {
 
 	// Default value
 	splitdumpInstance.SplitThresholdLineNumber = 1000
-	splitdumpInstance.ScannerBufferSizeKiloBytes = 512
+	splitdumpInstance.ScannerBufferSizeKiloBytes = 128
 
 	instanceFolderPath := strings.Replace(
 		fmt.Sprintf("%s/%s_single_instance",

--- a/utilities/ramcli/ramcli.go
+++ b/utilities/ramcli/ramcli.go
@@ -192,7 +192,7 @@ func RAMCli(deployment *Deployment) (err error) {
 		if err = deployment.configureStream2bqAssetTypes(); err != nil {
 			log.Fatal(err)
 		}
-		if err = deployment.configureUpload2gcsAssetTypes(); err != nil {
+		if err = deployment.configureUpload2gcsMetadataTypes(); err != nil {
 			log.Fatal(err)
 		}
 		if err = deployment.configureListGroupsDirectories(); err != nil {

--- a/utilities/solution/type_settings.go
+++ b/utilities/solution/type_settings.go
@@ -61,6 +61,8 @@ type Settings struct {
 				IAMPolicies         string `yaml:"IAMPolicies" valid:"isNotZeroValue"`
 				RAMViolation        string `yaml:"RAMViolation" valid:"isNotZeroValue"`
 				RAMComplianceStatus string `yaml:"RAMComplianceStatus" valid:"isNotZeroValue"`
+				GCIGroupMembers     string `yaml:"GCIGroupMembers" valid:"isNotZeroValue"`
+				GCIGroupSettings    string `yaml:"GCIGroupSettings" valid:"isNotZeroValue"`
 			} `yaml:"topicNames"`
 		}
 		FireStore struct {


### PR DESCRIPTION
splitdump default scanner buffer 128KB

move output topics names to solution.yaml
- listgroupmembers
- getgroupsettings
- ramcli config upload2gcs add
- iam-policies
- gci-group-dirxx
- gci-groupMembers
- gci-groupSettings