### PR TITLE
Fix getversion 

### DIFF
--- a/doc_dot_go_unit_test.go
+++ b/doc_dot_go_unit_test.go
@@ -37,6 +37,9 @@ func TestUnitDocDotGo(t *testing.T) {
 			if strings.HasSuffix(path, levelOneFolder) {
 				return nil
 			}
+			if strings.Contains(path, "testdata") {
+				return nil
+			}
 			_, err = os.Stat(path + "/" + docDotGoName)
 			if os.IsNotExist(err) {
 				t.Errorf("%v: missing %s file in this subfolder", path, docDotGoName)

--- a/utilities/ramcli/func_getversions.go
+++ b/utilities/ramcli/func_getversions.go
@@ -16,20 +16,20 @@ package ramcli
 
 import (
 	"bufio"
-	"log"
+	"fmt"
 	"os"
 	"strings"
-
-	"github.com/BrunoReboul/ram/utilities/ffo"
 )
 
 // getVersions look for a go.mod in the curent path, returns Go and RAM versions, crashes execution on errors
-func getVersions() (goVersion, ramVersion string) {
-	goModFilePath := "./go.mod"
-	ffo.CheckPath(goModFilePath)
+func getVersions(repositoryPath string) (goVersion, ramVersion string, err error) {
+	goModFilePath := repositoryPath + "/go.mod"
+	if _, err := os.Stat(goModFilePath); err != nil {
+		return "", "", err
+	}
 	file, err := os.Open(goModFilePath)
 	if err != nil {
-		log.Fatal(err)
+		return "", "", err
 	}
 	defer file.Close()
 
@@ -48,14 +48,13 @@ func getVersions() (goVersion, ramVersion string) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.Fatal(err)
+		return "", "", err
 	}
 	if goVersion == "" {
-		log.Fatalf("goVersion NOT found, missing go x.y line in go.mod")
+		return "", "", fmt.Errorf("goVersion NOT found, missing go x.y line in go.mod")
 	}
 	if ramVersion == "" {
-		log.Fatalf("ramVersion NOT found, missing reauire line to ram module in go.mod")
+		return "", "", fmt.Errorf("ramVersion NOT found, missing required line to ram module in go.mod")
 	}
-	log.Printf("goVersion %s, ramVersion %s", goVersion, ramVersion)
-	return goVersion, ramVersion
+	return goVersion, ramVersion, nil
 }

--- a/utilities/ramcli/func_getversions_unit_test.go
+++ b/utilities/ramcli/func_getversions_unit_test.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ramcli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUnitGetVersions(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		repositoryPath string
+		wantErrorMsg   string
+		wantGoVersion  string
+		wantRAMVersion string
+	}{
+		{
+			name:           "go113ram012rc04",
+			repositoryPath: "testdata/getversions/go113ram012rc04",
+			wantGoVersion:  "1.13",
+			wantRAMVersion: "v0.1.2-rc04",
+		},
+		{
+			name:           "noGoModFile",
+			repositoryPath: "blabla",
+			wantErrorMsg:   "no such file or directory",
+		},
+		{
+			name:           "missingGoVersion",
+			repositoryPath: "testdata/getversions/missinggoversion",
+			wantErrorMsg:   "goVersion NOT found",
+		},
+		{
+			name:           "missingRamVersion",
+			repositoryPath: "testdata/getversions/missingramversion",
+			wantErrorMsg:   "ramVersion NOT found",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc // https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			goVersion, ramVersion, err := getVersions(tc.repositoryPath)
+			if err != nil {
+				if tc.wantErrorMsg == "" {
+					t.Errorf("Did not expect an error an got %s", err.Error())
+				} else {
+					if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+						t.Errorf("Error message should contains '%s' and is", tc.wantErrorMsg)
+						t.Log(string('\n') + err.Error())
+					}
+				}
+			} else {
+				if tc.wantErrorMsg == "" {
+					if tc.wantGoVersion != goVersion {
+						t.Errorf("Want goversion %s got %s", tc.wantGoVersion, goVersion)
+					}
+					if tc.wantRAMVersion != ramVersion {
+						t.Errorf("Want goversion %s got %s", tc.wantGoVersion, goVersion)
+					}
+				} else {
+					t.Errorf("Expect this error did not get it %s", tc.wantErrorMsg)
+				}
+			}
+		})
+	}
+}

--- a/utilities/ramcli/ramcli.go
+++ b/utilities/ramcli/ramcli.go
@@ -107,11 +107,16 @@ func Initialize(ctx context.Context, deployment *Deployment) {
 
 // RAMCli Real-time Asset Monitor cli
 func RAMCli(deployment *Deployment) (err error) {
-	deployment.CheckArguments()
+	err = deployment.CheckArguments()
+	if err != nil {
+		return err
+	}
+	log.Printf("goVersion %s, ramVersion %s", deployment.Core.GoVersion, deployment.Core.RAMVersion)
+
 	solutionConfigFilePath := fmt.Sprintf("%s/%s", deployment.Core.RepositoryPath, solution.SolutionSettingsFileName)
 	err = ffo.ReadValidate("", "SolutionSettings", solutionConfigFilePath, &deployment.Core.SolutionSettings)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	deployment.Core.SolutionSettings.Situate(deployment.Core.EnvironmentName)
 	deployment.Core.ProjectNumber, err = getProjectNumber(deployment.Core.Ctx, deployment.Core.Services.CloudresourcemanagerService, deployment.Core.SolutionSettings.Hosting.ProjectID)
@@ -185,41 +190,41 @@ func RAMCli(deployment *Deployment) (err error) {
 	switch true {
 	case deployment.Core.Commands.Initialize:
 		if err = deployment.initialize(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 	case deployment.Core.Commands.ConfigureAssetTypes:
 		if err = deployment.configureSetFeedsAssetTypes(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if err = deployment.configureDumpInventoryAssetTypes(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if err = deployment.configureSplitDumpSingleInstance(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if err = deployment.configurePublish2fsInstances(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if err = deployment.configureStream2bqAssetTypes(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if err = deployment.configureUpload2gcsMetadataTypes(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if err = deployment.configureListGroupsDirectories(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if err = deployment.configureListGroupMembersDirectories(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if err = deployment.configureGetGroupSettingsDirectories(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if err = deployment.configureLogSinksOrganizations(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if err = deployment.configureConvertlog2feedOrganizations(); err != nil {
-			log.Fatal(err)
+			return err
 		}
 	default:
 		log.Printf("found %d instance(s)", len(deployment.Core.InstanceFolderRelativePaths))

--- a/utilities/ramcli/testdata/getversions/go113ram012rc04/go.mod
+++ b/utilities/ramcli/testdata/getversions/go113ram012rc04/go.mod
@@ -1,0 +1,7 @@
+module example.com/ramcli
+
+// 1.13.8 is the go version used in the go113 Cloud Function enviroment
+go 1.13
+
+require github.com/BrunoReboul/ram v0.1.2-rc04
+

--- a/utilities/ramcli/testdata/getversions/missinggoversion/go.mod
+++ b/utilities/ramcli/testdata/getversions/missinggoversion/go.mod
@@ -1,0 +1,4 @@
+module example.com/ramcli
+
+require github.com/BrunoReboul/ram v0.1.2-rc04
+

--- a/utilities/ramcli/testdata/getversions/missingramversion/go.mod
+++ b/utilities/ramcli/testdata/getversions/missingramversion/go.mod
@@ -1,0 +1,5 @@
+module example.com/ramcli
+
+// 1.13.8 is the go version used in the go113 Cloud Function enviroment
+go 1.13
+


### PR DESCRIPTION
- fix: Fixes #34 utilities/ramcli/func_getversions.go
- refactor: do not use log.Fatal, return err 
  - utilities/ramcli/ramcli.go
  - utilities/ramcli/func_checkargumemts.go
  - utilities/ramcli/func_getversions.go
- test: exclude `testdata` folders from doc_dot_go_unit_test.go
- test: add utilities/ramcli/func_getversions_unit_test.go and related testdata