### PR TITLE
feat_checktriggers

### DIFF
--- a/utilities/deploy/type_core.go
+++ b/utilities/deploy/type_core.go
@@ -72,6 +72,7 @@ type Core struct {
 		ConfigureAssetTypes bool
 		MakeReleasePipeline bool
 		Deploy              bool
+		Check               bool
 		Dumpsettings        bool
 	} `yaml:"-"`
 }

--- a/utilities/erm/doc.go
+++ b/utilities/erm/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package erm helps with errors management
+package erm

--- a/utilities/erm/func_isnottransientelsewait.go
+++ b/utilities/erm/func_isnottransientelsewait.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package erm
+
+import (
+	"log"
+	"strings"
+	"time"
+)
+
+// IsNotTransientElseWait check is the error is a 5xx and wait if it is
+func IsNotTransientElseWait(err error, waitSec time.Duration) (isNotTransient bool) {
+	erroMessage := err.Error()
+	transientErrors := []string{"500", "501", "502", "503", "504", "505", "506", "507", "508", "510", "511"}
+	isNotTransient = true
+	for _, transientError := range transientErrors {
+		if strings.Contains(erroMessage, transientError) {
+			isNotTransient = false
+			break
+		}
+	}
+	if !isNotTransient {
+		log.Printf("Transient error, wait %d sec and retry %s", waitSec, erroMessage)
+		time.Sleep(waitSec * time.Second)
+	}
+	return isNotTransient
+}

--- a/utilities/erm/func_isnottransientelsewait_unit_test.go
+++ b/utilities/erm/func_isnottransientelsewait_unit_test.go
@@ -1,0 +1,107 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package erm
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUnitIsNotTransientElseWait(t *testing.T) {
+	var testCases = []struct {
+		name                   string
+		errMessage             string
+		shouldNotFindTransient bool
+	}{
+		{
+			name:                   "err403",
+			errMessage:             "403 forbidden",
+			shouldNotFindTransient: true,
+		},
+		{
+			name:                   "err500",
+			errMessage:             "500 Internal Server Error",
+			shouldNotFindTransient: false,
+		},
+		{
+			name:                   "err501",
+			errMessage:             "501 Not Implemented",
+			shouldNotFindTransient: false,
+		},
+		{
+			name:                   "err502",
+			errMessage:             "502 Bad Gateway",
+			shouldNotFindTransient: false,
+		},
+		{
+			name:                   "err503",
+			errMessage:             "503 Service Unavailable",
+			shouldNotFindTransient: false,
+		},
+		{
+			name:                   "err504",
+			errMessage:             "504 Gateway Timeout",
+			shouldNotFindTransient: false,
+		},
+		{
+			name:                   "err505",
+			errMessage:             "505 HTTP Version Not Supported",
+			shouldNotFindTransient: false,
+		},
+		{
+			name:                   "err506",
+			errMessage:             "506 Variant Also Negotiates",
+			shouldNotFindTransient: false,
+		},
+		{
+			name:                   "err507",
+			errMessage:             "507 Insufficient Storage",
+			shouldNotFindTransient: false,
+		},
+		{
+			name:                   "err508",
+			errMessage:             "508 Loop Detected",
+			shouldNotFindTransient: false,
+		},
+		{
+			name:                   "err510",
+			errMessage:             "510 Not Extended",
+			shouldNotFindTransient: false,
+		},
+		{
+			name:                   "err511",
+			errMessage:             "511 Network Authentication Required",
+			shouldNotFindTransient: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := fmt.Errorf(tc.errMessage)
+			result := IsNotTransientElseWait(err, 0)
+			if tc.shouldNotFindTransient {
+				if tc.shouldNotFindTransient != result {
+					t.Errorf("Should NOT find transient in errMessage %s", tc.errMessage)
+				}
+			} else {
+				if tc.shouldNotFindTransient != result {
+					t.Errorf("Should find transient in errMessage %s", tc.errMessage)
+				}
+			}
+		})
+	}
+}

--- a/utilities/gcb/meth_triggerdeployment_deploy.go
+++ b/utilities/gcb/meth_triggerdeployment_deploy.go
@@ -17,6 +17,7 @@ package gcb
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 
 	"github.com/BrunoReboul/ram/utilities/solution"
@@ -24,12 +25,13 @@ import (
 )
 
 var globalTriggerDeployment *TriggerDeployment
+var count int
 
 // Permission cloudbuild.builds.get is required in complemenet of cloudbuild.builds.list, event if 'get' API is not used
 
-// Deploy delete is exist, then create a cloud build trigger to deploy a microservice instance
+// Deploy delete if exist, then create a cloud build trigger to deploy a microservice instance
 func (triggerDeployment *TriggerDeployment) Deploy() (err error) {
-	log.Printf("%s gcb cloud build trigger", triggerDeployment.Core.InstanceName)
+	// log.Printf("%s gcb cloud build trigger", triggerDeployment.Core.InstanceName)
 	if triggerDeployment.Settings.Service.GCB.QueueTTL == "" {
 		triggerDeployment.Settings.Service.GCB.QueueTTL = triggerDeployment.Core.SolutionSettings.Hosting.GCB.QueueTTL
 	}
@@ -37,21 +39,128 @@ func (triggerDeployment *TriggerDeployment) Deploy() (err error) {
 	triggerDeployment.situate()
 	// ffo.JSONMarshalIndentPrint(&triggerDeployment.Artifacts.BuildTrigger)
 	globalTriggerDeployment = triggerDeployment
-	triggerDeployment.deleteTriggers()
-	buildTrigger, err := triggerDeployment.Artifacts.ProjectsTriggersService.Create(triggerDeployment.Core.SolutionSettings.Hosting.ProjectID,
-		&triggerDeployment.Artifacts.BuildTrigger).Context(triggerDeployment.Core.Ctx).Do()
-	if err != nil {
+	if triggerDeployment.Core.Commands.Check {
+		if err = triggerDeployment.checkTrigger(); err != nil {
+			return err
+		}
+		log.Printf("%s gcb trigger checked", globalTriggerDeployment.Core.InstanceName)
+	} else {
+		if err = triggerDeployment.deleteTriggers(); err != nil {
+			return err
+		}
+		buildTrigger, err := triggerDeployment.Artifacts.ProjectsTriggersService.Create(triggerDeployment.Core.SolutionSettings.Hosting.ProjectID,
+			&triggerDeployment.Artifacts.BuildTrigger).Context(triggerDeployment.Core.Ctx).Do()
+		if err != nil {
+			return err
+		}
+		// ffo.JSONMarshalIndentPrint(buildTrigger)
+		log.Printf("%s gcb created trigger %s id %s with tag filter %s", globalTriggerDeployment.Core.InstanceName, buildTrigger.Name, buildTrigger.Id, buildTrigger.TriggerTemplate.TagName)
+	}
+	return nil
+}
+
+func (triggerDeployment *TriggerDeployment) checkTrigger() (err error) {
+	count = 0
+	if err = triggerDeployment.Artifacts.ProjectsTriggersService.List(triggerDeployment.Core.SolutionSettings.Hosting.ProjectID).Pages(triggerDeployment.Core.Ctx, browseTriggerToCheck); err != nil {
 		return err
 	}
-	// ffo.JSONMarshalIndentPrint(buildTrigger)
-	log.Printf("%s gcb created trigger %s id %s with tag filter %s", globalTriggerDeployment.Core.InstanceName, buildTrigger.Name, buildTrigger.Id, buildTrigger.TriggerTemplate.TagName)
+	if count == 0 {
+		return fmt.Errorf("%s gcb trigger NOT found for this instance", globalTriggerDeployment.Core.InstanceName)
+	}
+	return nil
+}
+
+func browseTriggerToCheck(response *cloudbuild.ListBuildTriggersResponse) error {
+	for _, buildtrigger := range response.Triggers {
+		if buildtrigger.Name == globalTriggerDeployment.Artifacts.BuildTrigger.Name {
+			count++
+			if err := checkBuildTrigger(buildtrigger); err != nil {
+				return err
+			}
+		}
+	}
+	if count > 1 {
+		return fmt.Errorf("%s gcb found more than one trigger for this instance", globalTriggerDeployment.Core.InstanceName)
+	}
+	return nil
+}
+
+func checkBuildTrigger(buildtrigger *cloudbuild.BuildTrigger) (err error) {
+	// A least one trigger maching the instance name has been found, check its configuration
+	var s string
+	if buildtrigger.Description != globalTriggerDeployment.Artifacts.BuildTrigger.Description {
+		s = fmt.Sprintf("%sdescription\nwant %s\nhave %s\n", s,
+			globalTriggerDeployment.Artifacts.BuildTrigger.Description,
+			buildtrigger.Description)
+	}
+	if len(buildtrigger.Build.Steps) != len(globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps) {
+		s = fmt.Sprintf("%sunexpected_number_of_steps\nwant %d\nhave %d\n", s,
+			len(globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps),
+			len(buildtrigger.Build.Steps))
+	} else {
+		for i := range globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps {
+			if globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps[i].Id != buildtrigger.Build.Steps[i].Id {
+				s = fmt.Sprintf("%sbuild_step_%d_id\nwant %s\nhave %s\n", s, i,
+					globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps[i].Id,
+					buildtrigger.Build.Steps[i].Id)
+			}
+			if globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps[i].Name != buildtrigger.Build.Steps[i].Name {
+				s = fmt.Sprintf("%sbuild_step_%d_name\nwant %s\nhave %s\n", s, i,
+					globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps[i].Name,
+					buildtrigger.Build.Steps[i].Name)
+			}
+			if !reflect.DeepEqual(globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps[i].Args, buildtrigger.Build.Steps[i].Args) {
+				s = fmt.Sprintf("%sbuild_step_%d_args\nwant %s\nhave %s\n", s, i,
+					strings.Join(globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps[i].Args[:], " "),
+					strings.Join(buildtrigger.Build.Steps[i].Args[:], " "))
+			}
+			if globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps[i].Entrypoint != buildtrigger.Build.Steps[i].Entrypoint {
+				s = fmt.Sprintf("%sbuild_step_%d_entryPoint\nwant %s\nhave %s\n", s, i,
+					globalTriggerDeployment.Artifacts.BuildTrigger.Build.Steps[i].Entrypoint,
+					buildtrigger.Build.Steps[i].Entrypoint)
+			}
+		}
+	}
+	if buildtrigger.Build.Timeout != globalTriggerDeployment.Artifacts.BuildTrigger.Build.Timeout {
+		s = fmt.Sprintf("%sbuild_timeout\nwant %s\nhave %s\n", s,
+			globalTriggerDeployment.Artifacts.BuildTrigger.Build.Timeout,
+			buildtrigger.Build.Timeout)
+	}
+	if buildtrigger.Build.QueueTtl != globalTriggerDeployment.Artifacts.BuildTrigger.Build.QueueTtl {
+		s = fmt.Sprintf("%sbuild_queueTtl\nwant %s\nhave %s\n", s,
+			globalTriggerDeployment.Artifacts.BuildTrigger.Build.QueueTtl,
+			buildtrigger.Build.QueueTtl)
+	}
+	if !reflect.DeepEqual(buildtrigger.Build.Tags, globalTriggerDeployment.Artifacts.BuildTrigger.Build.Tags) {
+		s = fmt.Sprintf("%sbuild_tags\nwant %s\nhave %s\n", s,
+			strings.Join(globalTriggerDeployment.Artifacts.BuildTrigger.Build.Tags[:], ","),
+			strings.Join(buildtrigger.Build.Tags[:], ","))
+	}
+	if buildtrigger.TriggerTemplate.ProjectId != globalTriggerDeployment.Artifacts.BuildTrigger.TriggerTemplate.ProjectId {
+		s = fmt.Sprintf("%striggerTemplate_projectId\nwant %s\nhave %s\n", s,
+			globalTriggerDeployment.Artifacts.BuildTrigger.TriggerTemplate.ProjectId,
+			buildtrigger.TriggerTemplate.ProjectId)
+	}
+	if buildtrigger.TriggerTemplate.RepoName != globalTriggerDeployment.Artifacts.BuildTrigger.TriggerTemplate.RepoName {
+		s = fmt.Sprintf("%striggerTemplate_repoName\nwant %s\nhave %s\n", s,
+			globalTriggerDeployment.Artifacts.BuildTrigger.TriggerTemplate.RepoName,
+			buildtrigger.TriggerTemplate.RepoName)
+	}
+	if buildtrigger.TriggerTemplate.TagName != globalTriggerDeployment.Artifacts.BuildTrigger.TriggerTemplate.TagName {
+		s = fmt.Sprintf("%striggerTemplate_tagName\nwant %s\nhave %s\n", s,
+			globalTriggerDeployment.Artifacts.BuildTrigger.TriggerTemplate.TagName, buildtrigger.TriggerTemplate.TagName)
+	}
+
+	if len(s) > 0 {
+		return fmt.Errorf("%s gcb invalid trigger configuration:\n%s", globalTriggerDeployment.Core.InstanceName, s)
+	}
 	return nil
 }
 
 func (triggerDeployment *TriggerDeployment) deleteTriggers() (err error) {
 	err = triggerDeployment.Artifacts.ProjectsTriggersService.List(triggerDeployment.Core.SolutionSettings.Hosting.ProjectID).Pages(triggerDeployment.Core.Ctx, browseTriggerToDelete)
 	if err != nil {
-		return fmt.Errorf("ProjectsTriggersService.List %v", err)
+		return fmt.Errorf("ProjectsTriggersService.List for deleting %v", err)
 	}
 	return nil
 }

--- a/utilities/ramcli/func_checkargumemts.go
+++ b/utilities/ramcli/func_checkargumemts.go
@@ -29,6 +29,7 @@ func (deployment *Deployment) CheckArguments() (err error) {
 	flag.BoolVar(&deployment.Core.Commands.ConfigureAssetTypes, "config", false, "For assets types defined in solution.yaml writes setfeeds, dumpinventory, stream2bq instance.yaml files and subfolders")
 	flag.BoolVar(&deployment.Core.Commands.MakeReleasePipeline, "pipe", false, "make release pipeline using cloud build to deploy one instance, one microservice, or all")
 	flag.BoolVar(&deployment.Core.Commands.Deploy, "deploy", false, "deploy one microservice instance")
+	flag.BoolVar(&deployment.Core.Commands.Check, "check", false, "with -pipe it checks if configured instances have a cloud build trigger, with -deploy a running cloud function")
 	flag.BoolVar(&deployment.Core.Commands.Dumpsettings, "dump", false, fmt.Sprintf("dump all settings in %s", solution.SettingsFileName))
 	flag.StringVar(&deployment.Core.RepositoryPath, "repo", ".", "Path to the root of the code repository")
 	flag.StringVar(&deployment.Core.RamcliServiceAccount, "ramclisa", "", "Email of Service Account used when running ramcli")
@@ -40,6 +41,14 @@ func (deployment *Deployment) CheckArguments() (err error) {
 	deployment.Core.GoVersion, deployment.Core.RAMVersion, err = getVersions(deployment.Core.RepositoryPath)
 	if err != nil {
 		return err
+	}
+	if deployment.Core.Commands.Check {
+		if !deployment.Core.Commands.MakeReleasePipeline && !deployment.Core.Commands.Deploy {
+			return fmt.Errorf("-check can be used only in conjuction with -pipe or -deploy")
+		}
+	}
+	if deployment.Core.Commands.Deploy && deployment.Core.Commands.MakeReleasePipeline {
+		return fmt.Errorf("-pipe and -deploy are mutually exclusive, starts with -pipe then do -deploy")
 	}
 	// case one instance
 	if *instanceFolderName != "" {

--- a/utilities/ramcli/func_checkargumemts.go
+++ b/utilities/ramcli/func_checkargumemts.go
@@ -57,7 +57,8 @@ func (deployment *Deployment) CheckArguments() (err error) {
 
 	if *microserviceFolderName != "" {
 		// case one microservice
-		deployment.Core.InstanceFolderRelativePaths, err = ffo.GetChild(deployment.Core.RepositoryPath, fmt.Sprintf("%s/%s/%s", solution.MicroserviceParentFolderName, *microserviceFolderName, solution.InstancesFolderName))
+		deployment.Core.InstanceFolderRelativePaths, err = ffo.GetChild(deployment.Core.RepositoryPath,
+			fmt.Sprintf("%s/%s/%s", solution.MicroserviceParentFolderName, *microserviceFolderName, solution.InstancesFolderName))
 		if err != nil {
 			return err
 		}

--- a/utilities/ramcli/func_checkargumemts.go
+++ b/utilities/ramcli/func_checkargumemts.go
@@ -25,7 +25,6 @@ import (
 
 // CheckArguments check cli arguments and build the list of microservices instances
 func (deployment *Deployment) CheckArguments() (err error) {
-	// flag.BoolVar(&settings.Commands.Makeyaml, "migrate-to-yaml", false, "make yaml settings files for setting.sh file")
 	flag.BoolVar(&deployment.Core.Commands.Initialize, "init", false, "initial setup to be launched first, before manual, aka not automatable setup tasks")
 	flag.BoolVar(&deployment.Core.Commands.ConfigureAssetTypes, "config", false, "For assets types defined in solution.yaml writes setfeeds, dumpinventory, stream2bq instance.yaml files and subfolders")
 	flag.BoolVar(&deployment.Core.Commands.MakeReleasePipeline, "pipe", false, "make release pipeline using cloud build to deploy one instance, one microservice, or all")
@@ -48,11 +47,11 @@ func (deployment *Deployment) CheckArguments() (err error) {
 			return fmt.Errorf("Missing service argument")
 		}
 		instanceRelativePath := fmt.Sprintf("%s/%s/%s/%s", solution.MicroserviceParentFolderName, *microserviceFolderName, solution.InstancesFolderName, *instanceFolderName)
-		deployment.Core.InstanceFolderRelativePaths = []string{instanceRelativePath}
 		instancePath := fmt.Sprintf("%s/%s", deployment.Core.RepositoryPath, instanceRelativePath)
 		if _, err := os.Stat(instancePath); err != nil {
 			return err
 		}
+		deployment.Core.InstanceFolderRelativePaths = []string{instanceRelativePath}
 		return nil
 	}
 

--- a/utilities/ramcli/meth_deployment_deployconvertlog2feed.go
+++ b/utilities/ramcli/meth_deployment_deployconvertlog2feed.go
@@ -34,6 +34,7 @@ func (deployment *Deployment) deployConvertLog2Feed() (err error) {
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
+		deployment.Core.AssetType = ""
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {

--- a/utilities/ramcli/meth_deployment_deployconvertlog2feed.go
+++ b/utilities/ramcli/meth_deployment_deployconvertlog2feed.go
@@ -29,12 +29,13 @@ func (deployment *Deployment) deployConvertLog2Feed() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploydumpinventory.go
+++ b/utilities/ramcli/meth_deployment_deploydumpinventory.go
@@ -29,7 +29,8 @@ func (deployment *Deployment) deployDumpInventory() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
@@ -37,7 +38,7 @@ func (deployment *Deployment) deployDumpInventory() (err error) {
 			deployment.Core.AssetType = instanceDeployment.Settings.Instance.CAI.AssetTypes[0]
 		}
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploydumpinventory.go
+++ b/utilities/ramcli/meth_deployment_deploydumpinventory.go
@@ -36,6 +36,8 @@ func (deployment *Deployment) deployDumpInventory() (err error) {
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		if instanceDeployment.Settings.Instance.CAI.ContentType == "RESOURCE" {
 			deployment.Core.AssetType = instanceDeployment.Settings.Instance.CAI.AssetTypes[0]
+		} else {
+			deployment.Core.AssetType = ""
 		}
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:

--- a/utilities/ramcli/meth_deployment_deploygetgroupsettings.go
+++ b/utilities/ramcli/meth_deployment_deploygetgroupsettings.go
@@ -29,12 +29,13 @@ func (deployment *Deployment) deployGetGroupSettings() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploygetgroupsettings.go
+++ b/utilities/ramcli/meth_deployment_deploygetgroupsettings.go
@@ -34,6 +34,7 @@ func (deployment *Deployment) deployGetGroupSettings() (err error) {
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
+		deployment.Core.AssetType = ""
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {

--- a/utilities/ramcli/meth_deployment_deployinstancereleasepipeline.go
+++ b/utilities/ramcli/meth_deployment_deployinstancereleasepipeline.go
@@ -14,51 +14,8 @@
 
 package ramcli
 
-// deployInstanceReleasePipeline an instance trigger
+// deployInstanceReleasePipeline deploys the cloud build trigger related to an instance
 func (deployment *Deployment) deployInstanceReleasePipeline() (err error) {
-	if err = deployment.enableBILBillingAccountOnProject(); err != nil {
-		return err
-	}
-	if err = deployment.deployGSUAPI(); err != nil {
-		return err
-	}
-	// Extended hosting org
-	if err = deployment.deployIAMHostingOrgRole(); err != nil {
-		return err
-	}
-	if err = deployment.deployGRMHostingOrgBindings(); err != nil {
-		return err
-	}
-	// Extended monitoring org
-	if err = deployment.deployIAMMonitoringOrgRole(); err != nil {
-		return err
-	}
-	if err = deployment.deployGRMMonitoringOrgBindings(); err != nil {
-		return err
-	}
-	// Extended folder
-	if err = deployment.deployGRMFolder(); err != nil {
-		return err
-	}
-	if err = deployment.deployGRMProject(); err != nil {
-		return err
-	}
-	if err = deployment.deployIAMProjectRoles(); err != nil {
-		return err
-	}
-	if err = deployment.deployGRMProjectBindings(); err != nil {
-		return err
-	}
-	if err = deployment.deployIAMServiceAccount(); err != nil {
-		return err
-	}
-	if err = deployment.deployIAMBindings(); err != nil {
-		return err
-	}
-	// Core folder
-	if err = deployment.deployGSRRepo(); err != nil {
-		return err
-	}
 	if err = deployment.deployGCBTrigger(); err != nil {
 		return err
 	}

--- a/utilities/ramcli/meth_deployment_deploylistgroupmembers.go
+++ b/utilities/ramcli/meth_deployment_deploylistgroupmembers.go
@@ -34,6 +34,7 @@ func (deployment *Deployment) deployListGroupMembers() (err error) {
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
+		deployment.Core.AssetType = ""
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {

--- a/utilities/ramcli/meth_deployment_deploylistgroupmembers.go
+++ b/utilities/ramcli/meth_deployment_deploylistgroupmembers.go
@@ -29,12 +29,13 @@ func (deployment *Deployment) deployListGroupMembers() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploylistgroups.go
+++ b/utilities/ramcli/meth_deployment_deploylistgroups.go
@@ -34,6 +34,7 @@ func (deployment *Deployment) deployListGroups() (err error) {
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
+		deployment.Core.AssetType = ""
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {

--- a/utilities/ramcli/meth_deployment_deploylistgroups.go
+++ b/utilities/ramcli/meth_deployment_deploylistgroups.go
@@ -29,12 +29,13 @@ func (deployment *Deployment) deployListGroups() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploymonitor.go
+++ b/utilities/ramcli/meth_deployment_deploymonitor.go
@@ -29,12 +29,13 @@ func (deployment *Deployment) deployMonitor() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploymonitor.go
+++ b/utilities/ramcli/meth_deployment_deploymonitor.go
@@ -15,6 +15,8 @@
 package ramcli
 
 import (
+	"strings"
+
 	"github.com/BrunoReboul/ram/services/monitor"
 )
 
@@ -34,6 +36,11 @@ func (deployment *Deployment) deployMonitor() (err error) {
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
+		if strings.Contains(instanceDeployment.Settings.Instance.GCF.TriggerTopic, "cai-rces-") {
+			deployment.Core.AssetType = strings.Replace(strings.Replace(instanceDeployment.Settings.Instance.GCF.TriggerTopic, "cai-rces-", "", -1), "-", ".placeholder/", -1)
+		} else {
+			deployment.Core.AssetType = ""
+		}
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {

--- a/utilities/ramcli/meth_deployment_deploypublish2fs.go
+++ b/utilities/ramcli/meth_deployment_deploypublish2fs.go
@@ -29,12 +29,13 @@ func (deployment *Deployment) deployPublish2fs() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploypublish2fs.go
+++ b/utilities/ramcli/meth_deployment_deploypublish2fs.go
@@ -15,6 +15,8 @@
 package ramcli
 
 import (
+	"strings"
+
 	"github.com/BrunoReboul/ram/services/publish2fs"
 )
 
@@ -34,6 +36,11 @@ func (deployment *Deployment) deployPublish2fs() (err error) {
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
+		if strings.Contains(instanceDeployment.Settings.Instance.GCF.TriggerTopic, "cai-rces-") {
+			deployment.Core.AssetType = strings.Replace(strings.Replace(instanceDeployment.Settings.Instance.GCF.TriggerTopic, "cai-rces-", "", -1), "-", ".placeholder/", -1)
+		} else {
+			deployment.Core.AssetType = ""
+		}
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {

--- a/utilities/ramcli/meth_deployment_deployreleasepipelineprerequisites.go
+++ b/utilities/ramcli/meth_deployment_deployreleasepipelineprerequisites.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ramcli
+
+// deployReleasePipelinePrerequsites deploy once the prerequisites to create then cloud build triggers
+func (deployment *Deployment) deployReleasePipelinePrerequsites() (err error) {
+	if err = deployment.enableBILBillingAccountOnProject(); err != nil {
+		return err
+	}
+	if err = deployment.deployGSUAPI(); err != nil {
+		return err
+	}
+	// Extended hosting org
+	if err = deployment.deployIAMHostingOrgRole(); err != nil {
+		return err
+	}
+	if err = deployment.deployGRMHostingOrgBindings(); err != nil {
+		return err
+	}
+	// Extended monitoring org
+	if err = deployment.deployIAMMonitoringOrgRole(); err != nil {
+		return err
+	}
+	if err = deployment.deployGRMMonitoringOrgBindings(); err != nil {
+		return err
+	}
+	// Extended folder
+	if err = deployment.deployGRMFolder(); err != nil {
+		return err
+	}
+	if err = deployment.deployGRMProject(); err != nil {
+		return err
+	}
+	if err = deployment.deployIAMProjectRoles(); err != nil {
+		return err
+	}
+	if err = deployment.deployGRMProjectBindings(); err != nil {
+		return err
+	}
+	if err = deployment.deployIAMServiceAccount(); err != nil {
+		return err
+	}
+	if err = deployment.deployIAMBindings(); err != nil {
+		return err
+	}
+	// Core folder
+	if err = deployment.deployGSRRepo(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/utilities/ramcli/meth_deployment_deploysetfeeds.go
+++ b/utilities/ramcli/meth_deployment_deploysetfeeds.go
@@ -36,6 +36,8 @@ func (deployment *Deployment) deploySetFeeds() (err error) {
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		if instanceDeployment.Settings.Instance.CAI.ContentType == "RESOURCE" {
 			deployment.Core.AssetType = instanceDeployment.Settings.Instance.CAI.AssetTypes[0]
+		} else {
+			deployment.Core.AssetType = ""
 		}
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:

--- a/utilities/ramcli/meth_deployment_deploysetfeeds.go
+++ b/utilities/ramcli/meth_deployment_deploysetfeeds.go
@@ -29,7 +29,8 @@ func (deployment *Deployment) deploySetFeeds() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
@@ -37,7 +38,7 @@ func (deployment *Deployment) deploySetFeeds() (err error) {
 			deployment.Core.AssetType = instanceDeployment.Settings.Instance.CAI.AssetTypes[0]
 		}
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploysetlogsinks.go
+++ b/utilities/ramcli/meth_deployment_deploysetlogsinks.go
@@ -34,6 +34,7 @@ func (deployment *Deployment) deploySetLogSinks() (err error) {
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
+		deployment.Core.AssetType = ""
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {

--- a/utilities/ramcli/meth_deployment_deploysetlogsinks.go
+++ b/utilities/ramcli/meth_deployment_deploysetlogsinks.go
@@ -29,12 +29,13 @@ func (deployment *Deployment) deploySetLogSinks() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploysplitdump.go
+++ b/utilities/ramcli/meth_deployment_deploysplitdump.go
@@ -34,6 +34,7 @@ func (deployment *Deployment) deploySplitDump() (err error) {
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
+		deployment.Core.AssetType = ""
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {

--- a/utilities/ramcli/meth_deployment_deploysplitdump.go
+++ b/utilities/ramcli/meth_deployment_deploysplitdump.go
@@ -29,12 +29,13 @@ func (deployment *Deployment) deploySplitDump() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploystream2bq.go
+++ b/utilities/ramcli/meth_deployment_deploystream2bq.go
@@ -31,7 +31,8 @@ func (deployment *Deployment) deployStream2bq() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
@@ -39,7 +40,7 @@ func (deployment *Deployment) deployStream2bq() (err error) {
 			deployment.Core.AssetType = strings.Replace(strings.Replace(instanceDeployment.Settings.Instance.GCF.TriggerTopic, "cai-rces-", "", -1), "-", ".placeholder/", -1)
 		}
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/meth_deployment_deploystream2bq.go
+++ b/utilities/ramcli/meth_deployment_deploystream2bq.go
@@ -38,6 +38,8 @@ func (deployment *Deployment) deployStream2bq() (err error) {
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		if strings.Contains(instanceDeployment.Settings.Instance.GCF.TriggerTopic, "cai-rces-") {
 			deployment.Core.AssetType = strings.Replace(strings.Replace(instanceDeployment.Settings.Instance.GCF.TriggerTopic, "cai-rces-", "", -1), "-", ".placeholder/", -1)
+		} else {
+			deployment.Core.AssetType = ""
 		}
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:

--- a/utilities/ramcli/meth_deployment_deployupload2gcs.go
+++ b/utilities/ramcli/meth_deployment_deployupload2gcs.go
@@ -38,6 +38,8 @@ func (deployment *Deployment) deployUpload2gcs() (err error) {
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
 		if strings.Contains(instanceDeployment.Settings.Instance.GCF.TriggerTopic, "cai-rces-") {
 			deployment.Core.AssetType = strings.Replace(strings.Replace(instanceDeployment.Settings.Instance.GCF.TriggerTopic, "cai-rces-", "", -1), "-", ".placeholder/", -1)
+		} else {
+			deployment.Core.AssetType = ""
 		}
 		err = deployment.deployInstanceReleasePipeline()
 	case deployment.Core.Commands.Deploy:

--- a/utilities/ramcli/meth_deployment_deployupload2gcs.go
+++ b/utilities/ramcli/meth_deployment_deployupload2gcs.go
@@ -31,7 +31,8 @@ func (deployment *Deployment) deployUpload2gcs() (err error) {
 	if err != nil {
 		return err
 	}
-	if deployment.Core.Commands.MakeReleasePipeline {
+	switch true {
+	case deployment.Core.Commands.MakeReleasePipeline:
 		deployment.Settings.Service.GCB = instanceDeployment.Settings.Service.GCB
 		deployment.Settings.Service.IAM = instanceDeployment.Settings.Service.IAM
 		deployment.Settings.Service.GSU = instanceDeployment.Settings.Service.GSU
@@ -39,7 +40,7 @@ func (deployment *Deployment) deployUpload2gcs() (err error) {
 			deployment.Core.AssetType = strings.Replace(strings.Replace(instanceDeployment.Settings.Instance.GCF.TriggerTopic, "cai-rces-", "", -1), "-", ".placeholder/", -1)
 		}
 		err = deployment.deployInstanceReleasePipeline()
-	} else {
+	case deployment.Core.Commands.Deploy:
 		if deployment.Core.Commands.Deploy {
 			err = instanceDeployment.Deploy()
 		}

--- a/utilities/ramcli/ramcli.go
+++ b/utilities/ramcli/ramcli.go
@@ -126,6 +126,7 @@ func RAMCli(deployment *Deployment) (err error) {
 	if err != nil {
 		return fmt.Errorf("ERROR - google.FindDefaultCredentials %v", err)
 	}
+	// BQ client cannot be initiated in the Intialize func as other clients as it requires the projdctID that is know only at this stage
 	deployment.Core.Services.BigqueryClient, err = bigquery.NewClient(deployment.Core.Ctx, deployment.Core.SolutionSettings.Hosting.ProjectID, option.WithCredentials(creds))
 	if err != nil {
 		return err
@@ -133,6 +134,7 @@ func RAMCli(deployment *Deployment) (err error) {
 
 	if deployment.Core.AssetType != "" {
 		// For one (new) assetType build the list of related instances to deploy accross services. aka transversal point of view
+		// Cannot be done in checkarguments like for other deployments as requires orgIDs list that is available only after ReadValidate
 		var instanceFolderRelativePaths []string
 		for _, organizationID := range deployment.Core.SolutionSettings.Monitoring.OrganizationIDs {
 			serviceName := "setfeeds"

--- a/utilities/str/func_find_unit_test.go
+++ b/utilities/str/func_find_unit_test.go
@@ -56,11 +56,11 @@ func TestUnitFind(t *testing.T) {
 			result := Find(tc.slice, tc.val)
 			if tc.shouldPass {
 				if tc.shouldPass != result {
-					t.Errorf("Should find string '%s' ins slice %v", tc.val, tc.slice)
+					t.Errorf("Should find string '%s' in slice %v", tc.val, tc.slice)
 				}
 			} else {
 				if tc.shouldPass != result {
-					t.Errorf("Should NOT find string '%s' ins slice %v", tc.val, tc.slice)
+					t.Errorf("Should NOT find string '%s' in slice %v", tc.val, tc.slice)
 				}
 			}
 		})


### PR DESCRIPTION
fix #40
fix #39 
fix #44 
fix #45 

* feat: As RAM manager, I want a tool to check if configured instances have a cloud build trigger so that it saves time to do this control
* feat: Check cloud build trigger prerequisite once instead of for each trigger to deploy so ramcli -pipe take less time to execute and log is cleaner
* feat: Add retry on cloud build 503 transient errors to ramcli -pipe when it provision the triggers
* feat: erm package to help with error management / retry on transients
*fix: weird cloud build trigger tags on asset types 

