### PR TITLE
Refactor and improve SQL Views

### DIFF
--- a/services/convertlog2feed/core.go
+++ b/services/convertlog2feed/core.go
@@ -835,12 +835,9 @@ func publishGroupMemberCreationOrUpdate(groupEmail string, memberEmail string, g
 	groupID = group.Id
 
 	var feedMessage cai.FeedMessageMember
-	feedMessage.Asset.Ancestors = []string{
-		fmt.Sprintf("groups/%s", groupID),
-		fmt.Sprintf("directories/%s", global.directoryCustomerID)}
-
-	feedMessage.Asset.AncestryPath = fmt.Sprintf("directories/%s/groups/%s", global.directoryCustomerID, groupID)
-	feedMessage.Asset.Name = "//" + feedMessage.Asset.AncestryPath + "/members/" + groupMember.Id
+	feedMessage.Asset.Ancestors = []string{fmt.Sprintf("directories/%s", global.directoryCustomerID)}
+	feedMessage.Asset.AncestryPath = fmt.Sprintf("directories/%s", global.directoryCustomerID)
+	feedMessage.Asset.Name = fmt.Sprintf("//directories/%s/groups/%s/members/%s", global.directoryCustomerID, groupID, groupMember.Id)
 	feedMessage.Asset.AssetType = "www.googleapis.com/admin/directory/members"
 	feedMessage.Asset.Resource.GroupEmail = groupEmail
 	feedMessage.Asset.Resource.MemberEmail = memberEmail
@@ -1033,6 +1030,7 @@ func publishGroupSettings(groupEmail string, global *Global) (err error) {
 	}
 	groupID = group.Id
 
+	feedMessageGroupSettings.Asset.AncestryPath = fmt.Sprintf("directories/%s", global.directoryCustomerID)
 	feedMessageGroupSettings.Asset.Ancestors = []string{fmt.Sprintf("directories/%s", global.directoryCustomerID)}
 	feedMessageGroupSettings.Asset.Name = fmt.Sprintf("//directories/%s/groups/%s/groupSettings", global.directoryCustomerID, groupID)
 

--- a/services/getgroupsettings/core.go
+++ b/services/getgroupsettings/core.go
@@ -249,6 +249,7 @@ func EntryPoint(ctxEvent context.Context, PubSubMessage gps.PubSubMessage, globa
 	feedMessageGroupSettings.Window.StartTime = metadata.Timestamp
 	feedMessageGroupSettings.Origin = feedMessageGroup.Origin
 	feedMessageGroupSettings.Asset.Ancestors = feedMessageGroup.Asset.Ancestors
+	feedMessageGroupSettings.Asset.AncestryPath = feedMessageGroup.Asset.AncestryPath
 	feedMessageGroupSettings.Asset.AssetType = "groupssettings.googleapis.com/groupSettings"
 	feedMessageGroupSettings.Asset.Name = feedMessageGroup.Asset.Name + "/groupSettings"
 	feedMessageGroupSettings.Deleted = feedMessageGroup.Deleted

--- a/services/listgroupmembers/core.go
+++ b/services/listgroupmembers/core.go
@@ -43,6 +43,7 @@ import (
 // Global variable to deal with GroupsListCall Pages constraint: no possible to pass variable to the function in pages()
 // https://pkg.go.dev/google.golang.org/api/admin/directory/v1?tab=doc#GroupsListCall.Pages
 var ancestors []string
+var ancestryPath string
 var ctx context.Context
 var environment string
 var groupAssetName string
@@ -287,12 +288,8 @@ func EntryPoint(ctxEvent context.Context, PubSubMessage gps.PubSubMessage, globa
 	pubSubErrNumber = 0
 	groupAssetName = feedMessageGroup.Asset.Name
 	groupEmail = feedMessageGroup.Asset.Resource.Email
-	// First ancestor is my parent
-	ancestors = []string{fmt.Sprintf("groups/%s", feedMessageGroup.Asset.Resource.Id)}
-	// Next ancestors are my parent ancestors
-	for _, ancestor := range feedMessageGroup.Asset.Ancestors {
-		ancestors = append(ancestors, ancestor)
-	}
+	ancestors = feedMessageGroup.Asset.Ancestors
+	ancestryPath = feedMessageGroup.Asset.AncestryPath
 	origin = feedMessageGroup.Origin
 	if feedMessageGroup.Deleted {
 		// retreive members from cache
@@ -468,7 +465,7 @@ func browseMembers(members *admin.Members) error {
 		feedMessageMember.Window.StartTime = timestamp
 		feedMessageMember.Origin = origin
 		feedMessageMember.Asset.Ancestors = ancestors
-		feedMessageMember.Asset.AncestryPath = groupAssetName
+		feedMessageMember.Asset.AncestryPath = ancestryPath
 		feedMessageMember.Asset.AssetType = "www.googleapis.com/admin/directory/members"
 		feedMessageMember.Asset.Name = groupAssetName + "/members/" + member.Id
 		feedMessageMember.Asset.Resource.GroupEmail = groupEmail

--- a/services/stream2bq/meth_instancedeployment_deploygbqrces.go
+++ b/services/stream2bq/meth_instancedeployment_deploygbqrces.go
@@ -25,20 +25,24 @@ func (instanceDeployment *InstanceDeployment) deployGBQRces() (err error) {
 	tableName := instanceDeployment.Settings.Instance.Bigquery.TableName
 	datasetLocation := instanceDeployment.Core.SolutionSettings.Hosting.Bigquery.Dataset.Location
 	datasetName := instanceDeployment.Core.SolutionSettings.Hosting.Bigquery.Dataset.Name
+	intervalDays := instanceDeployment.Core.SolutionSettings.Hosting.Bigquery.Views.IntervalDays
+	if intervalDays == 0 {
+		intervalDays = 365
+	}
 
 	switch tableName {
 	case "complianceStatus":
-		_, err = gbq.GetComplianceStatus(instanceDeployment.Core.Ctx, instanceDeployment.Core.Services.BigqueryClient, datasetLocation, datasetName)
+		_, err = gbq.GetComplianceStatus(instanceDeployment.Core.Ctx, instanceDeployment.Core.Services.BigqueryClient, datasetLocation, datasetName, intervalDays)
 		if err != nil {
 			return fmt.Errorf("gbq.GetComplianceStatus %v", err)
 		}
 	case "violations":
-		_, err = gbq.GetViolations(instanceDeployment.Core.Ctx, instanceDeployment.Core.Services.BigqueryClient, datasetLocation, datasetName)
+		_, err = gbq.GetViolations(instanceDeployment.Core.Ctx, instanceDeployment.Core.Services.BigqueryClient, datasetLocation, datasetName, intervalDays)
 		if err != nil {
 			return fmt.Errorf("gbq.GetViolations %v", err)
 		}
 	case "assets":
-		_, err = gbq.GetAssets(instanceDeployment.Core.Ctx, instanceDeployment.Core.Services.BigqueryClient, datasetLocation, datasetName)
+		_, err = gbq.GetAssets(instanceDeployment.Core.Ctx, instanceDeployment.Core.Services.BigqueryClient, datasetLocation, datasetName, intervalDays)
 		if err != nil {
 			return fmt.Errorf("gbq.GetAssets %v", err)
 		}

--- a/services/stream2bq/meth_instancedeployment_deploygbqrces.go
+++ b/services/stream2bq/meth_instancedeployment_deploygbqrces.go
@@ -16,6 +16,7 @@ package stream2bq
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/BrunoReboul/ram/utilities/gbq"
 )
@@ -29,6 +30,7 @@ func (instanceDeployment *InstanceDeployment) deployGBQRces() (err error) {
 	if intervalDays == 0 {
 		intervalDays = 365
 	}
+	log.Printf("gbq views intervalDays %d", intervalDays)
 
 	switch tableName {
 	case "complianceStatus":

--- a/utilities/cai/func_getdisplayname.go
+++ b/utilities/cai/func_getdisplayname.go
@@ -27,8 +27,8 @@ import (
 )
 
 // getDisplayName retrieive the friendly name of an ancestor
-func getDisplayName(ctx context.Context, name string, collectionID string, firestoreClient *firestore.Client, cloudresourcemanagerService *cloudresourcemanager.Service, cloudresourcemanagerServiceV2 *cloudresourcemanagerv2.Service) string {
-	var displayName = "unknown"
+func getDisplayName(ctx context.Context, name string, collectionID string, firestoreClient *firestore.Client, cloudresourcemanagerService *cloudresourcemanager.Service, cloudresourcemanagerServiceV2 *cloudresourcemanagerv2.Service) (displayName string) {
+	displayName = strings.Replace(name, "/", "_", -1)
 	ancestorType := strings.Split(name, "/")[0]
 	knownAncestorTypes := []string{"organizations", "folders", "projects"}
 	if !str.Find(knownAncestorTypes, ancestorType) {

--- a/utilities/cai/type_assetandfeed.go
+++ b/utilities/cai/type_assetandfeed.go
@@ -35,11 +35,12 @@ type assetGroup struct {
 
 // assetGroupSettings CAI like format
 type assetGroupSettings struct {
-	Name      string                 `json:"name"`
-	AssetType string                 `json:"assetType"`
-	Ancestors []string               `json:"ancestors"`
-	IamPolicy json.RawMessage        `json:"iamPolicy"`
-	Resource  *groupssettings.Groups `json:"resource"`
+	Name         string                 `json:"name"`
+	AssetType    string                 `json:"assetType"`
+	Ancestors    []string               `json:"ancestors"`
+	AncestryPath string                 `json:"ancestryPath"`
+	IamPolicy    json.RawMessage        `json:"iamPolicy"`
+	Resource     *groupssettings.Groups `json:"resource"`
 }
 
 // assetMember CAI like format

--- a/utilities/gbq/func_createupdateview.go
+++ b/utilities/gbq/func_createupdateview.go
@@ -23,18 +23,18 @@ import (
 	"cloud.google.com/go/bigquery"
 )
 
-func createUpdateView(ctx context.Context, tableName string, dataset *bigquery.Dataset) (err error) {
+func createUpdateView(ctx context.Context, tableName string, dataset *bigquery.Dataset, intervalDays int64) (err error) {
 	var viewName, query string
 	switch tableName {
 	case "complianceStatus":
 		viewName = "last_compliancestatus"
-		query = getLastComplianceStatusQuery(dataset.ProjectID, dataset.DatasetID)
+		query = getLastComplianceStatusQuery(dataset.ProjectID, dataset.DatasetID, intervalDays)
 	case "violations":
 		viewName = "active_violations"
-		query = getActiveViolationsQuery(dataset.ProjectID, dataset.DatasetID)
+		query = getActiveViolationsQuery(dataset.ProjectID, dataset.DatasetID, intervalDays)
 	case "assets":
 		viewName = "last_assets"
-		query = getLastAssetsQuery(dataset.ProjectID, dataset.DatasetID)
+		query = getLastAssetsQuery(dataset.ProjectID, dataset.DatasetID, intervalDays)
 	}
 	table := dataset.Table(viewName)
 	tableMetadataRetreived, err := table.Metadata(ctx)

--- a/utilities/gbq/func_createupdateview.go
+++ b/utilities/gbq/func_createupdateview.go
@@ -88,7 +88,7 @@ func createUpdateView(ctx context.Context, tableName string, dataset *bigquery.D
 		tableMetadataToUpdate.UseLegacySQL = false
 		tableMetadataRetreived, err = table.Update(ctx, tableMetadataToUpdate, "")
 		if err != nil {
-			return fmt.Errorf("ERROR when updating view %s %v", viewName, err)
+			return fmt.Errorf("ERROR when updating view %s %v \n%s", viewName, err, query)
 		}
 		log.Printf("View updated %s", tableMetadataRetreived.Name)
 	}

--- a/utilities/gbq/func_getactiveviolationsquery.go
+++ b/utilities/gbq/func_getactiveviolationsquery.go
@@ -48,8 +48,7 @@ FROM
     AND violations.functionConfig.deploymentTime = compliancestatus.ruleDeploymentTimeStamp
     AND violations.feedMessage.asset.name = compliancestatus.assetName
     AND violations.feedMessage.window.startTime = compliancestatus.assetInventoryTimeStamp
-WHERE
-    serviceName = "gci"`
+`
 
 func getActiveViolationsQuery(projectID string, datasetName string, intervalDays int64) (query string) {
 	lastComplianceStatusViewName := fmt.Sprintf("`%s.%s.last_compliancestatus`", projectID, datasetName)

--- a/utilities/gbq/func_getactiveviolationsquery.go
+++ b/utilities/gbq/func_getactiveviolationsquery.go
@@ -55,6 +55,6 @@ func getActiveViolationsQuery(projectID string, datasetName string, intervalDays
 	query = strings.Replace(activeViolationsQuery, "<last_compliancestatus>", lastComplianceStatusViewName, -1)
 	violationsTableName := fmt.Sprintf("`%s.%s.violations`", projectID, datasetName)
 	query = strings.Replace(query, "<violations>", violationsTableName, -1)
-	query = strings.Replace(query, "<intervalDays>", string(intervalDays), -1)
+	query = strings.Replace(query, "<intervalDays>", fmt.Sprintf("%d", intervalDays), -1)
 	return query
 }

--- a/utilities/gbq/func_getactiveviolationsquery.go
+++ b/utilities/gbq/func_getactiveviolationsquery.go
@@ -42,7 +42,7 @@ FROM
     FROM
       <violations>
     WHERE
-      DATE(_PARTITIONTIME) > DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)
+      DATE(_PARTITIONTIME) > DATE_SUB(CURRENT_DATE(), INTERVAL <intervalDays> DAY)
       OR _PARTITIONTIME IS NULL
   ) AS violations ON violations.functionConfig.functionName = <last_compliancestatus>.ruleName
   AND violations.functionConfig.deploymentTime = <last_compliancestatus>.ruleDeploymentTimeStamp
@@ -50,10 +50,11 @@ FROM
   AND violations.feedMessage.window.startTime = <last_compliancestatus>.assetInventoryTimeStamp
 `
 
-func getActiveViolationsQuery(projectID string, datasetName string) (query string) {
+func getActiveViolationsQuery(projectID string, datasetName string, intervalDays int64) (query string) {
 	lastComplianceStatusViewName := fmt.Sprintf("`%s.%s.last_compliancestatus`", projectID, datasetName)
 	query = strings.Replace(activeViolationsQuery, "<last_compliancestatus>", lastComplianceStatusViewName, -1)
 	violationsTableName := fmt.Sprintf("`%s.%s.violations`", projectID, datasetName)
 	query = strings.Replace(query, "<violations>", violationsTableName, -1)
+	query = strings.Replace(query, "<intervalDays>", string(intervalDays), -1)
 	return query
 }

--- a/utilities/gbq/func_getactiveviolationsquery.go
+++ b/utilities/gbq/func_getactiveviolationsquery.go
@@ -21,34 +21,35 @@ import (
 
 const activeViolationsQuery = `
 SELECT
-  violations.*,
-  <last_compliancestatus>.serviceName,
-  <last_compliancestatus>.ruleNameShort,
-  SPLIT(feedmessage.asset.ancestryPathDisplayName, "/") [SAFE_OFFSET(0)] AS level0,
-  SPLIT(feedmessage.asset.ancestryPathDisplayName, "/") [SAFE_OFFSET(1)] AS level1,
-  SPLIT(feedmessage.asset.ancestryPathDisplayName, "/") [SAFE_OFFSET(2)] AS level2,
-  SPLIT(feedmessage.asset.ancestryPathDisplayName, "/") [SAFE_OFFSET(3)] AS level3,
-  SPLIT(feedmessage.asset.ancestryPathDisplayName, "/") [SAFE_OFFSET(4)] AS level4,
-  SPLIT(feedmessage.asset.ancestryPathDisplayName, "/") [SAFE_OFFSET(5)] AS level5,
-  SPLIT(feedmessage.asset.ancestryPathDisplayName, "/") [SAFE_OFFSET(6)] AS level6,
-  SPLIT(feedmessage.asset.ancestryPathDisplayName, "/") [SAFE_OFFSET(7)] AS level7,
-  SPLIT(feedmessage.asset.ancestryPathDisplayName, "/") [SAFE_OFFSET(8)] AS level8,
-  SPLIT(feedmessage.asset.ancestryPathDisplayName, "/") [SAFE_OFFSET(9)] AS level9
+    violations.*,
+    compliancestatus.serviceName,
+    compliancestatus.ruleNameShort,
+    compliancestatus.level0,
+    compliancestatus.level1,
+    compliancestatus.level2,
+    compliancestatus.level3,
+    compliancestatus.level4,
+    compliancestatus.level5,
+    compliancestatus.level6,
+    compliancestatus.level7,
+    compliancestatus.level8,
+    compliancestatus.level9
 FROM
-  <last_compliancestatus>
-  INNER JOIN (
-    SELECT
-      *
-    FROM
-      <violations>
-    WHERE
-      DATE(_PARTITIONTIME) > DATE_SUB(CURRENT_DATE(), INTERVAL <intervalDays> DAY)
-      OR _PARTITIONTIME IS NULL
-  ) AS violations ON violations.functionConfig.functionName = <last_compliancestatus>.ruleName
-  AND violations.functionConfig.deploymentTime = <last_compliancestatus>.ruleDeploymentTimeStamp
-  AND violations.feedMessage.asset.name = <last_compliancestatus>.assetName
-  AND violations.feedMessage.window.startTime = <last_compliancestatus>.assetInventoryTimeStamp
-`
+    <last_compliancestatus> AS compliancestatus
+    INNER JOIN (
+        SELECT
+            *
+        FROM
+          <violations>
+        WHERE
+            DATE(_PARTITIONTIME) > DATE_SUB(CURRENT_DATE(), INTERVAL <intervalDays> DAY)
+            OR _PARTITIONTIME IS NULL
+    ) AS violations ON violations.functionConfig.functionName = compliancestatus.ruleName
+    AND violations.functionConfig.deploymentTime = compliancestatus.ruleDeploymentTimeStamp
+    AND violations.feedMessage.asset.name = compliancestatus.assetName
+    AND violations.feedMessage.window.startTime = compliancestatus.assetInventoryTimeStamp
+WHERE
+    serviceName = "gci"`
 
 func getActiveViolationsQuery(projectID string, datasetName string, intervalDays int64) (query string) {
 	lastComplianceStatusViewName := fmt.Sprintf("`%s.%s.last_compliancestatus`", projectID, datasetName)

--- a/utilities/gbq/func_getassets.go
+++ b/utilities/gbq/func_getassets.go
@@ -21,7 +21,7 @@ import (
 )
 
 // GetAssets provision assets table, view, and dependencies
-func GetAssets(ctx context.Context, bigQueryClient *bigquery.Client, location string, datasetName string) (table *bigquery.Table, err error) {
+func GetAssets(ctx context.Context, bigQueryClient *bigquery.Client, location string, datasetName string, intervalDays int64) (table *bigquery.Table, err error) {
 	tableName := "assets"
 	dataset, err := getDataset(ctx, datasetName, location, bigQueryClient)
 	if err != nil {
@@ -31,7 +31,7 @@ func GetAssets(ctx context.Context, bigQueryClient *bigquery.Client, location st
 	if err != nil {
 		return nil, err
 	}
-	err = createUpdateView(ctx, tableName, dataset)
+	err = createUpdateView(ctx, tableName, dataset, intervalDays)
 	if err != nil {
 		return nil, err
 	}

--- a/utilities/gbq/func_getcompliancestatus.go
+++ b/utilities/gbq/func_getcompliancestatus.go
@@ -21,7 +21,7 @@ import (
 )
 
 // GetComplianceStatus provision compliancestatus table, view, and dependencies
-func GetComplianceStatus(ctx context.Context, bigQueryClient *bigquery.Client, location string, datasetName string) (table *bigquery.Table, err error) {
+func GetComplianceStatus(ctx context.Context, bigQueryClient *bigquery.Client, location string, datasetName string, intervalDays int64) (table *bigquery.Table, err error) {
 	dataset, err := getDataset(ctx, datasetName, location, bigQueryClient)
 	if err != nil {
 		return nil, err
@@ -31,11 +31,11 @@ func GetComplianceStatus(ctx context.Context, bigQueryClient *bigquery.Client, l
 		return nil, err
 	}
 	// Ensure assets table and view exist
-	_, err = GetAssets(ctx, bigQueryClient, location, datasetName)
+	_, err = GetAssets(ctx, bigQueryClient, location, datasetName, intervalDays)
 	if err != nil {
 		return nil, err
 	}
-	err = createUpdateView(ctx, "complianceStatus", dataset)
+	err = createUpdateView(ctx, "complianceStatus", dataset, intervalDays)
 	if err != nil {
 		return nil, err
 	}

--- a/utilities/gbq/func_getlastassetsquery.go
+++ b/utilities/gbq/func_getlastassetsquery.go
@@ -30,7 +30,7 @@ FROM
         FROM
             <assets>
         WHERE
-            DATE(_PARTITIONTIME) > DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)
+            DATE(_PARTITIONTIME) > DATE_SUB(CURRENT_DATE(), INTERVAL <intervalDays> DAY)
             OR _PARTITIONTIME IS NULL
         GROUP BY
             name
@@ -43,13 +43,15 @@ FROM
         FROM
             <assets>
         WHERE
-            DATE(_PARTITIONTIME) > DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)
+            DATE(_PARTITIONTIME) > DATE_SUB(CURRENT_DATE(), INTERVAL <intervalDays> DAY)
             OR _PARTITIONTIME IS NULL
     ) AS assets ON assets.name = latest_assets.name
     AND assets.timestamp = latest_assets.timestamp
 `
 
-func getLastAssetsQuery(projectID string, datasetName string) (query string) {
+func getLastAssetsQuery(projectID string, datasetName string, intervalDays int64) (query string) {
 	assetsTableName := fmt.Sprintf("`%s.%s.assets`", projectID, datasetName)
-	return strings.Replace(lastAssetsQuery, "<assets>", assetsTableName, -1)
+	query = strings.Replace(lastAssetsQuery, "<assets>", assetsTableName, -1)
+	query = strings.Replace(query, "<intervalDays>", string(intervalDays), -1)
+	return query
 }

--- a/utilities/gbq/func_getlastassetsquery.go
+++ b/utilities/gbq/func_getlastassetsquery.go
@@ -52,6 +52,6 @@ FROM
 func getLastAssetsQuery(projectID string, datasetName string, intervalDays int64) (query string) {
 	assetsTableName := fmt.Sprintf("`%s.%s.assets`", projectID, datasetName)
 	query = strings.Replace(lastAssetsQuery, "<assets>", assetsTableName, -1)
-	query = strings.Replace(query, "<intervalDays>", string(intervalDays), -1)
+	query = strings.Replace(query, "<intervalDays>", fmt.Sprintf("%d", intervalDays), -1)
 	return query
 }

--- a/utilities/gbq/func_getlastcompliancestatusquery.go
+++ b/utilities/gbq/func_getlastcompliancestatusquery.go
@@ -181,6 +181,6 @@ func getLastComplianceStatusQuery(projectID string, datasetName string, interval
 	query = strings.Replace(lastComplianceStatusQuery, "<last_assets>", lastAssetsViewName, -1)
 	complianceStatusTableName := fmt.Sprintf("`%s.%s.complianceStatus`", projectID, datasetName)
 	query = strings.Replace(query, "<complianceStatus>", complianceStatusTableName, -1)
-	query = strings.Replace(query, "<intervalDays>", string(intervalDays), -1)
+	query = strings.Replace(query, "<intervalDays>", fmt.Sprintf("%d", intervalDays), -1)
 	return query
 }

--- a/utilities/gbq/func_getlastcompliancestatusquery.go
+++ b/utilities/gbq/func_getlastcompliancestatusquery.go
@@ -20,17 +20,17 @@ import (
 )
 
 const lastComplianceStatusQuery = `
-WITH complianceStatus AS (
-  SELECT
+WITH complianceStatus0 AS (
+    SELECT
       *
-  FROM
+    FROM
       <complianceStatus>
-  WHERE
-      DATE(_PARTITIONTIME) > DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)
+    WHERE
+      DATE(_PARTITIONTIME) > DATE_SUB(CURRENT_DATE(), INTERVAL <intervalDays> DAY)
       OR _PARTITIONTIME IS NULL
-),
-assets AS (
-  SELECT
+  ),
+  assets AS (
+    SELECT
       name,
       owner,
       violationResolver,
@@ -39,106 +39,148 @@ assets AS (
       ancestorsDisplayName,
       ancestors,
       assetType
-  FROM
+    FROM
       <last_assets>
 ),
-latest_asset_inventory_per_rule AS (
-  SELECT
+  latest_asset_inventory_per_rule AS (
+    SELECT
       assetName,
       ruleName,
       MAX(assetInventoryTimeStamp) AS assetInventoryTimeStamp
-  FROM
-      complianceStatus
-  GROUP BY
+    FROM
+      complianceStatus0
+    GROUP BY
       assetName,
       ruleName
-  ORDER BY
+    ORDER BY
       assetName,
       ruleName
-),
-latest_rules AS (
-  SELECT
+  ),
+  latest_rules AS (
+    SELECT
       ruleName,
       MAX(ruleDeploymentTimeStamp) AS ruleDeploymentTimeStamp
-  FROM
-      complianceStatus
-  GROUP BY
+    FROM
+      complianceStatus0
+    GROUP BY
       ruleName
-  ORDER BY
+    ORDER BY
       ruleName
-),
-status_for_latest_rules AS (
-  SELECT
-      complianceStatus.*
-  FROM
+  ),
+  status_for_latest_rules AS (
+    SELECT
+      complianceStatus0.*
+    FROM
       latest_rules
-      INNER JOIN complianceStatus ON complianceStatus.ruleName = latest_rules.ruleName
-      AND complianceStatus.ruleDeploymentTimeStamp = latest_rules.ruleDeploymentTimeStamp
-),
-complianceStates AS (
-  SELECT
+      INNER JOIN complianceStatus0 ON complianceStatus0.ruleName = latest_rules.ruleName
+      AND complianceStatus0.ruleDeploymentTimeStamp = latest_rules.ruleDeploymentTimeStamp
+  ),
+  complianceStatus1 AS (
+    SELECT
       status_for_latest_rules.ruleName,
       SPLIT(
-          REPLACE(status_for_latest_rules.ruleName, "monitor_", ""),
-          "_"
+        REPLACE(status_for_latest_rules.ruleName, "monitor_", ""),
+        "_"
       ) [SAFE_OFFSET(0)] AS serviceName,
       status_for_latest_rules.ruleDeploymentTimeStamp,
       status_for_latest_rules.compliant,
       status_for_latest_rules.assetName,
       status_for_latest_rules.assetInventoryTimeStamp,
-  FROM
+      IF(
+        SPLIT(status_for_latest_rules.assetName, "/") [SAFE_OFFSET(2)] = "directories",
+        CONCAT(
+          SPLIT(status_for_latest_rules.assetName, "/") [SAFE_OFFSET(2)],
+          "/",
+          SPLIT(status_for_latest_rules.assetName, "/") [SAFE_OFFSET(3)]
+        ),
+        NULL
+      ) AS directoryPath,
+      IF(
+        SPLIT(status_for_latest_rules.assetName, "/") [SAFE_OFFSET(2)] = "directories",
+        CASE
+          SPLIT(status_for_latest_rules.assetName, "/") [SAFE_OFFSET(6)]
+          WHEN "members" THEN "www.googleapis.com/admin/directory/members"
+          WHEN "groupSettings" THEN "groupssettings.googleapis.com/groupSettings"
+          ELSE NULL
+        END,
+        NULL
+      ) AS directoryAssetType,
+    FROM
       latest_asset_inventory_per_rule
       INNER JOIN status_for_latest_rules ON status_for_latest_rules.assetName = latest_asset_inventory_per_rule.assetName
       AND status_for_latest_rules.ruleName = latest_asset_inventory_per_rule.ruleName
       AND status_for_latest_rules.assetInventoryTimeStamp = latest_asset_inventory_per_rule.assetInventoryTimeStamp
-  WHERE
+    WHERE
       status_for_latest_rules.deleted = FALSE
-)
-SELECT
-  complianceStates.ruleName,
-  complianceStates.serviceName,
-  REPLACE(
-      complianceStates.ruleName,
-      CONCAT("monitor_", complianceStates.serviceName, "_"),
-      ""
-  ) AS ruleNameShort,
-  complianceStates.ruleDeploymentTimeStamp,
-  complianceStates.compliant,
-  NOT complianceStates.compliant AS notCompliant,
-  complianceStates.assetName,
-  complianceStates.assetInventoryTimeStamp,
-  assets.owner,
-  assets.violationResolver,
-  assets.ancestryPathDisplayName,
-  assets.ancestryPath,
-  assets.ancestorsDisplayName,
-  assets.ancestors,
-  assets.assetType,
-  SPLIT(assets.ancestryPathDisplayName, "/") [SAFE_OFFSET(0)] AS level0,
-  SPLIT(assets.ancestryPathDisplayName, "/") [SAFE_OFFSET(1)] AS level1,
-  SPLIT(assets.ancestryPathDisplayName, "/") [SAFE_OFFSET(2)] AS level2,
-  SPLIT(assets.ancestryPathDisplayName, "/") [SAFE_OFFSET(3)] AS level3,
-  SPLIT(assets.ancestryPathDisplayName, "/") [SAFE_OFFSET(4)] AS level4,
-  SPLIT(assets.ancestryPathDisplayName, "/") [SAFE_OFFSET(5)] AS level5,
-  SPLIT(assets.ancestryPathDisplayName, "/") [SAFE_OFFSET(6)] AS level6,
-  SPLIT(assets.ancestryPathDisplayName, "/") [SAFE_OFFSET(7)] AS level7,
-  SPLIT(assets.ancestryPathDisplayName, "/") [SAFE_OFFSET(8)] AS level8,
-  SPLIT(assets.ancestryPathDisplayName, "/") [SAFE_OFFSET(9)] AS level9
-FROM
-  complianceStates
-  LEFT JOIN assets ON complianceStates.assetName = assets.name
-ORDER BY
-  complianceStates.ruleName,
-  complianceStates.ruleDeploymentTimeStamp,
-  complianceStates.compliant,
-  complianceStates.assetName,
-  complianceStates.assetInventoryTimeStamp
+  ),
+  complianceStatus AS (
+    SELECT
+      complianceStatus1.ruleName,
+      complianceStatus1.serviceName,
+      REPLACE(
+        complianceStatus1.ruleName,
+        CONCAT("monitor_", complianceStatus1.serviceName, "_"),
+        ""
+      ) AS ruleNameShort,
+      complianceStatus1.ruleDeploymentTimeStamp,
+      complianceStatus1.compliant,
+      NOT complianceStatus1.compliant AS notCompliant,
+      complianceStatus1.assetName,
+      complianceStatus1.assetInventoryTimeStamp,
+      assets.owner,
+      assets.violationResolver,
+      IFNULL(
+        assets.ancestryPath,
+        complianceStatus1.directoryPath
+      ) AS ancestryPath,
+      IFNULL(
+        assets.ancestryPathDisplayName,
+        IFNULL(
+          assets.ancestryPath,
+          complianceStatus1.directoryPath
+        )
+      ) AS ancestryPathDisplayName,
+      IF(
+        ARRAY_LENGTH(assets.ancestorsDisplayName) > 0,
+        assets.ancestorsDisplayName,
+        assets.ancestors
+      ) AS ancestorsDisplayName,
+      assets.ancestors,
+      IFNULL(
+        assets.assetType,
+        complianceStatus1.directoryAssetType
+      ) AS assetType,
+    FROM
+      complianceStatus1
+      LEFT JOIN assets ON complianceStatus1.assetName = assets.name
+  )
+  SELECT
+    complianceStatus.*,
+    SPLIT(complianceStatus.ancestryPathDisplayName, "/") [SAFE_OFFSET(0)] AS level0,
+    SPLIT(complianceStatus.ancestryPathDisplayName, "/") [SAFE_OFFSET(1)] AS level1,
+    SPLIT(complianceStatus.ancestryPathDisplayName, "/") [SAFE_OFFSET(2)] AS level2,
+    SPLIT(complianceStatus.ancestryPathDisplayName, "/") [SAFE_OFFSET(3)] AS level3,
+    SPLIT(complianceStatus.ancestryPathDisplayName, "/") [SAFE_OFFSET(4)] AS level4,
+    SPLIT(complianceStatus.ancestryPathDisplayName, "/") [SAFE_OFFSET(5)] AS level5,
+    SPLIT(complianceStatus.ancestryPathDisplayName, "/") [SAFE_OFFSET(6)] AS level6,
+    SPLIT(complianceStatus.ancestryPathDisplayName, "/") [SAFE_OFFSET(7)] AS level7,
+    SPLIT(complianceStatus.ancestryPathDisplayName, "/") [SAFE_OFFSET(8)] AS level8,
+    SPLIT(complianceStatus.ancestryPathDisplayName, "/") [SAFE_OFFSET(9)] AS level9
+  FROM
+    complianceStatus
+  ORDER BY
+    complianceStatus.ruleName,
+    complianceStatus.ruleDeploymentTimeStamp,
+    complianceStatus.compliant,
+    complianceStatus.assetName,
+    complianceStatus.assetInventoryTimeStamp
 `
 
-func getLastComplianceStatusQuery(projectID string, datasetName string) (query string) {
+func getLastComplianceStatusQuery(projectID string, datasetName string, intervalDays int64) (query string) {
 	lastAssetsViewName := fmt.Sprintf("`%s.%s.last_assets`", projectID, datasetName)
 	query = strings.Replace(lastComplianceStatusQuery, "<last_assets>", lastAssetsViewName, -1)
 	complianceStatusTableName := fmt.Sprintf("`%s.%s.complianceStatus`", projectID, datasetName)
 	query = strings.Replace(query, "<complianceStatus>", complianceStatusTableName, -1)
+	query = strings.Replace(query, "<intervalDays>", string(intervalDays), -1)
 	return query
 }

--- a/utilities/gbq/func_getviolations.go
+++ b/utilities/gbq/func_getviolations.go
@@ -21,7 +21,7 @@ import (
 )
 
 // GetViolations provision violations table, view, and dependencies
-func GetViolations(ctx context.Context, bigQueryClient *bigquery.Client, location string, datasetName string) (table *bigquery.Table, err error) {
+func GetViolations(ctx context.Context, bigQueryClient *bigquery.Client, location string, datasetName string, intervalDays int64) (table *bigquery.Table, err error) {
 	dataset, err := getDataset(ctx, datasetName, location, bigQueryClient)
 	if err != nil {
 		return nil, err
@@ -31,11 +31,11 @@ func GetViolations(ctx context.Context, bigQueryClient *bigquery.Client, locatio
 		return nil, err
 	}
 	// Ensure lastCompliancestatus view exists
-	_, err = GetComplianceStatus(ctx, bigQueryClient, location, datasetName)
+	_, err = GetComplianceStatus(ctx, bigQueryClient, location, datasetName, intervalDays)
 	if err != nil {
 		return nil, err
 	}
-	err = createUpdateView(ctx, "violations", dataset)
+	err = createUpdateView(ctx, "violations", dataset, intervalDays)
 	if err != nil {
 		return nil, err
 	}

--- a/utilities/solution/type_settings.go
+++ b/utilities/solution/type_settings.go
@@ -60,6 +60,9 @@ type Settings struct {
 				Name     string `valid:"isNotZeroValue"`
 				Location string `valid:"isNotZeroValue"`
 			}
+			Views struct {
+				IntervalDays int64 `yaml:"intervalDays,omitempty"`
+			}
 		}
 		Pubsub struct {
 			TopicNames struct {


### PR DESCRIPTION
- refactor: getDisplayName 
  - previously: returns "unknown" when not able to find an asset display name
  - now: returns the asset name with underscore replacing slash
- refactor: GCI assets the ancestry path and ancestors list
  - previously: 
    - missing ancestry path for groupSettings
    - groupMember ancestry = directory id + group ID
  - now: 
    - all GCI asset have a consistent ancestryPath or ancestors list as "directories/xxx", where xxx is the customer directory ID
- refactor: SQL view
  - previously: as GCI assets are not persisted in asset table the following fileds were NULL in the last_compliancestatus view: `assetType`, `ancestryPath` and `level0` to 9
  - now: these filed are built by the view SQL code from the GCI asset name

- feat: `solution.yaml` has a new optional setting hosting/bigquery/views/intervalDays as a number of day to query in the tables. Aligning this setting the the frequency of the job starting the batch export of GCI assets, for example 7 days, enable to reduce the Bigquery cost in the same proportion: e.g. 7 instead of 365. Thanks to @MarcFundenberger for the idea.fixes #53