### PR TITLE
feat: compliant field (true/false) in `monitor` service finish logs entries

### DIFF
--- a/services/monitor/core.go
+++ b/services/monitor/core.go
@@ -529,6 +529,7 @@ func EntryPoint(ctxEvent context.Context, PubSubMessage gps.PubSubMessage, globa
 		LatencySeconds:       latency.Seconds(),
 		LatencyE2ESeconds:    latencyE2E.Seconds(),
 		StepStack:            global.stepStack,
+		Compliant:            complianceStatus.Compliant,
 	})
 	return nil
 }

--- a/utilities/logging/type_entry.go
+++ b/utilities/logging/type_entry.go
@@ -41,6 +41,7 @@ type Entry struct {
 	LatencySeconds             float64    `json:"latency_seconds,omitempty"`
 	LatencyE2ESeconds          float64    `json:"latency_e2e_seconds,omitempty"`
 	StepStack                  Steps      `json:"step_stack,omitempty"`
+	Compliant                  bool       `json:"compliant,omitempty"`
 }
 
 // Step defines a step in a serverless chain of events


### PR DESCRIPTION
fixes #109 